### PR TITLE
센고쿠 불멸 명칭 변경

### DIFF
--- a/ord-helper/assets.json
+++ b/ord-helper/assets.json
@@ -4708,7 +4708,7 @@
       },
       {
         "id": "E40h",
-        "name": "부처님",
+        "name": "센고쿠",
         "image": "https://raw.githubusercontent.com/tmo-gg/static.tmo.gg/main/ord-helper/images/sengokuim.webp",
         "commands": ["부처님센고쿠", "sengoku im"],
         "abilities": {


### PR DESCRIPTION
센고쿠 불멸의 이름이 부처님으로 변경된 것이 아니라 이명이 변경된 것이고, 친숙한 이름으로 표시되는게 더 낫다고 판단 됩니다.